### PR TITLE
Create an Apache Cordova version of the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/www/mgrs.html
+/platforms
+/res

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+APP_NAME=MGRS
+CONTENTS=www/mgrs.js www/mgrs.html
+CORDOVA_TARGETS=platforms
+
+.PHONY: all android ios test clean
+
+ALL=
+ifeq ($(shell which xcodebuild),)
+else
+	ALL+=ios
+endif
+
+ifeq ($(shell which android),)
+else
+	ALL+=android
+endif
+
+all: $(ALL)
+
+www/mgrs.html: mgrs.html .git/refs/heads
+	set -e;version=$$(git describe --dirty);sed -e '/<div id="versionquery">/s%$$%<a href="javascript:showversion('\'$$version\'');">?</a>%' <mgrs.html >$@
+
+android: platforms/android/build/outputs/apk/android-debug.apk
+
+ios: platforms/ios/build/$(APP_NAME).app
+
+platforms/android/build/outputs/apk/android-debug.apk: $(CONTENTS)
+	mkdir -p $(CORDOVA_TARGETS)
+	cordova platform add android
+	cordova build android
+
+platforms/ios/build/$(APP_NAME).app: $(CONTENTS)
+	mkdir -p $(CORDOVA_TARGETS)
+	cordova platform add ios
+	cordova build ios
+
+test: runtests www/mgrs.js
+	./runtests
+
+clean:
+	rm -rf $(CORDOVA_TARGETS) www/mgrs.html res

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+MGRS
+====
+
+MGRS is a mobile application for converting MGRS (Military Grid
+Reference System) to lat&lon geographic coordinates. It is based on
+the Geotrans library available at http://earth-info.nga.mil/GandG/geotrans/
+
+There are 2 versions of the application:
+
+Legacy
+------
+
+This remains the recommended version (for now).
+
+Apple iOS application. To use, open the "MGRS.xcodeproj" project
+in X-Code.
+
+Cordova
+-------
+
+NOTICE: For iOS, the legacy version remains recommended for now.
+The Cordova version has not been extensively tested yet and the
+auto-generated project may be missing some settings which are
+important.
+
+Uses Apache Cordova to automatically build a multi-platform mobile
+application from pure HTML & JavaScript source.
+
+To use for Android:
+
+ 1. Run "make android"
+ 2. Install "platforms/android/build/outputs/apk/android-debug.apk"
+
+To use for iOS:
+
+ 1. Run "make ios"
+ 2. Open the "platforms/ios/MGRS.xcodeproj* project in X-Code
+
+Other Makefile targets:
+
+ * all (default target): autodetect which platform(s) to build and do it.
+ * test
+ * clean

--- a/config.xml
+++ b/config.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="com.discoveryair.MGRS" version="0.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>MGRS</name>
+    <description>
+        MGRS to lat&lon conversion application
+    </description>
+    <author email="vandry@TZoNE.ORG">
+        Kim Vandry
+    </author>
+    <content src="mgrs.html" />
+    <icon src="mgrs57.png" />
+</widget>


### PR DESCRIPTION
For pure HTML & JavaScript applications (which this now is), Apache
Cordova allows multi-platform mobile applications to be created without
writing any platform-specific code or associated files at all. This
allows hiding all of the Apple-specific parts of the code behind
Cordova's automation, simplifying the source code, and adding (at least)
Android support to the application.

Because the Cordova version has not been extensively tested yet, the
Cordova version is hereby added alongside the legacy version and the
legacy version is not being deleted yet.

TODO: Make custom application icon work on iOS (works on Android)
TODO: Font size may be smaller in Cordova version; check & maybe fix
TODO: Is any special Cordova config required for iOS release builds?